### PR TITLE
Ros2 initialpose fix

### DIFF
--- a/robot_state_controller/include/robot_state_controller/drive_mode_switch.hpp
+++ b/robot_state_controller/include/robot_state_controller/drive_mode_switch.hpp
@@ -29,6 +29,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
+#include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "robot_state_controller/state.hpp"
 #include "robot_state_msgs/msg/state.hpp"

--- a/robot_state_controller/include/robot_state_controller/initial_point_publisher.hpp
+++ b/robot_state_controller/include/robot_state_controller/initial_point_publisher.hpp
@@ -46,6 +46,7 @@ public:
 
 private:
     // Param
+    tf2::Duration transform_tolerance_;
     std::string robot_frame_;
     std::string map_frame_;
     rclcpp::TimerBase::SharedPtr param_update_timer_;
@@ -60,7 +61,7 @@ private:
 
     // Pubs/Subs
     rclcpp::Subscription<robot_state_msgs::msg::DriveMode>::SharedPtr drive_mode_subscription_;
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr initial_point_publisher_;
+    rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initial_point_publisher_;
 
     // TF
     std::shared_ptr<tf2_ros::TransformListener> transform_listener_;

--- a/robot_state_controller/src/drive_mode_switch.cpp
+++ b/robot_state_controller/src/drive_mode_switch.cpp
@@ -45,7 +45,7 @@ DriveModeSwitch::DriveModeSwitch(rclcpp::NodeOptions options)
         std::bind(&DriveModeSwitch::joystick_callback, this, std::placeholders::_1)
     );
     controller_vel_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
-        "/ctrl_vel", 10,
+        "/cmd_vel", 10,
         std::bind(&DriveModeSwitch::controller_vel_callback, this, std::placeholders::_1)
     );
     navigation_vel_subscription_ = this->create_subscription<geometry_msgs::msg::Twist>(
@@ -53,14 +53,13 @@ DriveModeSwitch::DriveModeSwitch(rclcpp::NodeOptions options)
         std::bind(&DriveModeSwitch::navigation_vel_callback, this, std::placeholders::_1)
     );
     cmd_vel_publisher_ = this->create_publisher<geometry_msgs::msg::Twist>(
-        "/cmd_vel", 10
+        "/mammoth/cmd_vel", 10
     );
     drive_mode_publisher_ = this->create_publisher<robot_state_msgs::msg::DriveMode>(
         "/robot/drive_mode", 10
     );
-
     // Init values
-    last_system_state_ = State::System::KILL;
+    last_system_state_ = State::System::ACTIVE;
     last_drive_mode_state_ = State::DriveMode::TELEOP;
     last_switch_button_pressed_ = false;
 }


### PR DESCRIPTION
This PR changes the publisher topic from /initial_pose to /initialpose and also changes the initialpose topic type to geometry_msgs/msg/PoseWithCovarianceStamped. it also changes the topic published in subscribed in the drive_mode_switch to help ease the merge with the ros2 system